### PR TITLE
declare time_corrected as extern and remove antilag_list_players

### DIFF
--- a/include/g_local.h
+++ b/include/g_local.h
@@ -411,7 +411,7 @@ char		*clean_string(char *s);
 #define PRDFL_MIDAIR	1
 #define PRDFL_COILGUN	2
 #define PRDFL_FORCEOFF	255
-float			time_corrected;
+extern float		time_corrected;
 void			antilag_lagmove(antilag_t *data, float goal_time);
 void			antilag_lagmove_all_hitscan(gedict_t *e);
 void			antilag_lagmove_all_proj(gedict_t *owner, gedict_t *e);

--- a/src/antilag.c
+++ b/src/antilag.c
@@ -17,6 +17,7 @@ antilag_t *antilag_list_world;
 float antilag_nextthink_world;
 vec3_t antilag_origin;
 vec3_t antilag_retvec;
+float time_corrected;
 
 void Physics_PushEntityTrace(float push_x, float push_y, float push_z)
 {

--- a/src/client.c
+++ b/src/client.c
@@ -58,8 +58,6 @@ void item_megahealth_rot();
 void del_from_specs_favourites(gedict_t *rm);
 void item_megahealth_rot(void);
 
-antilag_t *antilag_list_players;
-
 extern int g_matchstarttime;
 
 void CheckAll()


### PR DESCRIPTION
time_corrected is a global variable declared in g_local.h and defined
in antilag.c. time_corrected is referenced by other translation units
by including the header. antilag_list_players is unused in client.c
and is a global variable in antilag.c.

This resolves linking errors with duplicate symbols on OpenBSD.